### PR TITLE
Handle SQLITE_MISUSE

### DIFF
--- a/sqlite3.go
+++ b/sqlite3.go
@@ -2188,7 +2188,7 @@ func (rc *SQLiteRows) Next(dest []driver.Value) error {
 // nextSyncLocked moves cursor to next; must be called with locked mutex.
 func (rc *SQLiteRows) nextSyncLocked(dest []driver.Value) error {
 	rv := C._sqlite3_step_internal(rc.s.s)
-	if rv == C.SQLITE_DONE {
+	if rv == C.SQLITE_DONE || rv == C.SQLITE_MISUSE {
 		return io.EOF
 	}
 	if rv != C.SQLITE_ROW {


### PR DESCRIPTION
This is an edge case, but results in a serious problem with this library. This is not ideal, but only happens if invalid input is fed to this library. Hopefully upstream will fix the code.