### PR TITLE
Enable SQLITE_ENABLE_COLUMN_METADATA permanently

### DIFF
--- a/sqlite3_opt_column_metadata.go
+++ b/sqlite3_opt_column_metadata.go
@@ -1,6 +1,3 @@
-//go:build sqlite_column_metadata
-// +build sqlite_column_metadata
-
 package sqlite3
 
 /*

--- a/sqlite3_opt_column_metadata_test.go
+++ b/sqlite3_opt_column_metadata_test.go
@@ -1,6 +1,3 @@
-//go:build sqlite_column_metadata
-// +build sqlite_column_metadata
-
 package sqlite3
 
 import "testing"


### PR DESCRIPTION
## Summary

Remove the `sqlite_column_metadata` build tag constraint so that `SQLITE_ENABLE_COLUMN_METADATA` is always compiled in. This makes `ColumnTableName()` available without requiring `-tags sqlite_column_metadata`.

This follows the same pattern as `SQLITE_ENABLE_PREUPDATE_HOOK`, which is already always enabled in this fork.

## Changes

- `sqlite3_opt_column_metadata.go` — Remove `//go:build sqlite_column_metadata` and `// +build sqlite_column_metadata` lines
- `sqlite3_opt_column_metadata_test.go` — Remove corresponding build tag lines

## Motivation

This change is needed to support table-qualified column names for JOIN queries in rqlite (see [rqlite/rqlite#2516](https://github.com/rqlite/rqlite/pull/2516)). Enabling column metadata permanently simplifies the build and removes the need for special build tags in downstream consumers.

## Test plan

- [x] `go build ./...` compiles without `-tags sqlite_column_metadata`
- [x] `go test ./...` passes, including `TestColumnTableName`
- [x] `ColumnTableName()` is available without build tags